### PR TITLE
Make plugin workable with Tiny Tiny Rss versions > 1.7.8

### DIFF
--- a/init.php
+++ b/init.php
@@ -17,6 +17,10 @@ class Flattr extends Plugin {
                         "https://github.com/nhoening/ttrss-flattr");
 	}
 
+	function api_version() {
+		return 2;
+	}
+
   function hook_article_button($line) {
 
     $rv = "";


### PR DESCRIPTION
The plugin don't work with Tiny Tiny Rss versions > 1.7.8. The pull request should this fix.
